### PR TITLE
Add a way to enable enum as flags without leaving its namespace using ADL

### DIFF
--- a/include/NazaraUtils/Flags.hpp
+++ b/include/NazaraUtils/Flags.hpp
@@ -17,19 +17,14 @@ namespace Nz
 {
 	// From: https://www.justsoftwaresolutions.co.uk/cplusplus/using-enum-classes-as-bitfields.html
 	template<typename E>
-	struct EnumAsFlags
-	{
-	};
+	struct EnumAsFlags;
 
 	// You can implement this in the same namespace as the enum thanks to ADL
 	template<typename T> constexpr bool EnableEnumAsNzFlags(T) { return false; };
 	template<typename T> constexpr bool EnableAutoFlagForNzFlags(T) { return true; };
 
-	template<typename, typename = void>
-	struct IsEnumFlag : std::false_type {};
-
-	template<typename T>
-	struct IsEnumFlag<T, std::void_t<decltype(EnumAsFlags<T>::max)>> : std::true_type {};
+	template<typename T, typename = void>
+	struct IsEnumFlag : std::bool_constant<IsComplete_v<T>> {};
 
 	template<typename T>
 	struct IsEnumFlag<T, std::void_t<std::enable_if_t<EnableEnumAsNzFlags(T{})>>> : std::true_type {};

--- a/include/NazaraUtils/Flags.hpp
+++ b/include/NazaraUtils/Flags.hpp
@@ -9,6 +9,7 @@
 
 #include <NazaraUtils/Prerequisites.hpp>
 #include <NazaraUtils/MathUtils.hpp>
+#include <NazaraUtils/TypeTraits.hpp>
 #include <iterator>
 #include <type_traits>
 
@@ -20,6 +21,9 @@ namespace Nz
 	{
 	};
 
+	// You can implement this in the same namespace as the enum thanks to ADL
+	template<typename T> constexpr bool EnableEnumAsNzFlags(T) { return false; };
+	template<typename T> constexpr bool EnableAutoFlagForNzFlags(T) { return true; };
 
 	template<typename, typename = void>
 	struct IsEnumFlag : std::false_type {};
@@ -27,20 +31,34 @@ namespace Nz
 	template<typename T>
 	struct IsEnumFlag<T, std::void_t<decltype(EnumAsFlags<T>::max)>> : std::true_type {};
 
-	template<typename, typename = void>
-	struct GetEnumAutoFlag : std::bool_constant<true> {};
-
 	template<typename T>
-	struct GetEnumAutoFlag<T, std::void_t<decltype(T::AutoFlag)>> : std::bool_constant<T::AutoFlag> {};
+	struct IsEnumFlag<T, std::void_t<std::enable_if_t<EnableEnumAsNzFlags(T{})>>> : std::true_type {};
+
+	template<typename E, typename = void>
+	struct GetEnumAutoFlag : std::bool_constant<EnableAutoFlagForNzFlags(E{})> {};
+
+	template<typename E>
+	struct GetEnumAutoFlag<E, std::void_t<decltype(E::AutoFlag)>> : std::bool_constant<E::AutoFlag> {};
+
+	template<typename E, typename = void>
+	struct GetEnumFlagMax
+	{
+		static constexpr std::size_t max = EnumValueCount<E>::value - 1;
+	};
+
+	template<typename E>
+	struct GetEnumFlagMax<E, std::void_t<decltype(EnumAsFlags<E>::max)>>
+	{
+		static constexpr std::size_t max = static_cast<std::size_t>(EnumAsFlags<E>::max);
+	};
 
 	template<typename E>
 	class Flags
 	{
 		static_assert(std::is_enum_v<E>, "Type must be an enumeration");
-		static_assert(IsEnumFlag<E>(), "Enum has not been enabled as flags by an EnumAsFlags specialization");
-		static_assert(std::is_same_v<std::remove_cv_t<decltype(EnumAsFlags<E>::max)>, E>, "EnumAsFlags field max should be of the same type as the enum");
+		static_assert(IsEnumFlag<E>(), "Enum has not been enabled as flags by an EnumAsFlags specialization nor EnableEnumAsNzFlags ADL function");
 
-		static constexpr std::size_t MaxValue = static_cast<std::size_t>(EnumAsFlags<E>::max);
+		static constexpr std::size_t MaxValue = GetEnumFlagMax<E>::max;
 		static constexpr bool AutoFlag = GetEnumAutoFlag<E>();
 
 		using BitField16 = std::conditional_t<(MaxValue >= 8), UInt16, UInt8>;

--- a/include/NazaraUtils/Flags.inl
+++ b/include/NazaraUtils/Flags.inl
@@ -280,12 +280,12 @@ namespace Nz
 	* Internally, every enum option is turned into a bit, this function allows to get a bitfield with only the bit of the enumeration value enabled.
 	*/
 	template<typename E>
-	constexpr typename Flags<E>::BitField Flags<E>::GetFlagValue(E enumValue)
+	constexpr auto Flags<E>::GetFlagValue(E enumValue) -> BitField
 	{
 		if constexpr (AutoFlag)
 			return 1U << static_cast<BitField>(enumValue);
 		else
-			return enumValue;
+			return static_cast<BitField>(enumValue);
 	}
 
 

--- a/include/NazaraUtils/Flags.inl
+++ b/include/NazaraUtils/Flags.inl
@@ -332,7 +332,7 @@ namespace Nz
 		if constexpr (AutoFlag)
 			return static_cast<T>(bitIndex - 1);
 		else
-			return static_cast<T>(1U << (bitIndex) - 1);
+			return static_cast<T>(1U << ((bitIndex) - 1));
 	}
 
 	/*!

--- a/include/NazaraUtils/Flags.inl
+++ b/include/NazaraUtils/Flags.inl
@@ -329,7 +329,10 @@ namespace Nz
 	{
 		unsigned int bitIndex = FindFirstBit(m_remainingFlags);
 		assert(bitIndex != 0);
-		return static_cast<T>(bitIndex - 1);
+		if constexpr (AutoFlag)
+			return static_cast<T>(bitIndex - 1);
+		else
+			return static_cast<T>(1U << (bitIndex) - 1);
 	}
 
 	/*!

--- a/include/NazaraUtils/TypeTraits.hpp
+++ b/include/NazaraUtils/TypeTraits.hpp
@@ -71,6 +71,30 @@ namespace Nz
 
 	/************************************************************************/
 
+	namespace Detail
+	{
+		template<typename T>
+		struct IsCompleteHelper
+		{
+			// SFINAE: sizeof in an incomplete type is an error, but since there's another specialization it won't result in a compilation error
+			template <typename U>
+			static auto test(U*) -> std::bool_constant<sizeof(U) == sizeof(U)>;
+
+			// less specialized overload
+			static auto test(...) -> std::false_type;
+
+			using type = decltype(test(static_cast<T*>(nullptr)));
+		};
+	}
+
+	template <typename T>
+	struct IsComplete : Detail::IsCompleteHelper<T>::type {};
+
+	template<typename T>
+	constexpr bool IsComplete_v = IsComplete<T>::value;
+
+	/************************************************************************/
+
 	// Helper for std::visit
 	template<typename... Ts> struct Overloaded : Ts...
 	{

--- a/tests/src/FlagTests.cpp
+++ b/tests/src/FlagTests.cpp
@@ -17,12 +17,30 @@ struct Nz::EnumAsFlags<Test>
 	static constexpr Test max = Test::C;
 };
 
-void TestIteration(TestFlags flags, std::initializer_list<Test> expected)
+namespace Foo
+{
+	enum class Test2
+	{
+		A = 1,
+		B = 2,
+		C = 4,
+
+		Count
+	};
+
+	constexpr bool EnableEnumAsNzFlags(Test2) { return true; }
+	constexpr bool EnableAutoFlagForNzFlags(Test2) { return false; }
+
+	using Test2Flags = Nz::Flags<Test2>;
+}
+
+template<typename E>
+void TestIteration(Nz::Flags<E> flags, std::initializer_list<E> expected)
 {
 	std::size_t count = 0;
 	auto it = expected.begin();
 
-	for (Test v : flags)
+	for (E v : flags)
 	{
 		CHECK(v == *it++);
 		count++;
@@ -33,10 +51,9 @@ void TestIteration(TestFlags flags, std::initializer_list<Test> expected)
 
 SCENARIO("Flags", "[Flags]")
 {
-	TestFlags flags = Test::A | Test::C;
-
 	WHEN("We test flags")
 	{
+		TestFlags flags = Test::A | Test::C;
 		CHECK(static_cast<Nz::UInt8>(flags) == (1 | 4));
 
 		CHECK(flags.Test(Test::A));
@@ -48,6 +65,7 @@ SCENARIO("Flags", "[Flags]")
 
 	WHEN("We clear some flags")
 	{
+		TestFlags flags = Test::A | Test::C;
 		flags.Clear(Test::B | Test::C);
 		CHECK(static_cast<Nz::UInt16>(flags) == 1);
 
@@ -60,6 +78,7 @@ SCENARIO("Flags", "[Flags]")
 
 	WHEN("We clear all flags")
 	{
+		TestFlags flags = Test::A | Test::C;
 		flags.Clear();
 		CHECK(static_cast<Nz::UInt32>(flags) == 0);
 
@@ -72,13 +91,14 @@ SCENARIO("Flags", "[Flags]")
 
 	WHEN("We set flags")
 	{
-		flags.Set(Test::B | Test::C);
+		Foo::Test2Flags flags = Foo::Test2::A | Foo::Test2::C;
+		flags.Set(Foo::Test2::B | Foo::Test2::C);
 		CHECK(static_cast<Nz::UInt64>(flags) == (1 | 2 | 4));
 
-		CHECK(flags.Test(Test::A));
-		CHECK(flags.Test(Test::B));
-		CHECK(flags.Test(Test::C));
+		CHECK(flags.Test(Foo::Test2::A));
+		CHECK(flags.Test(Foo::Test2::B));
+		CHECK(flags.Test(Foo::Test2::C));
 
-		TestIteration(flags, { Test::A, Test::B, Test::C });
+		TestIteration(flags, { Foo::Test2::A, Foo::Test2::B, Foo::Test2::C });
 	}
 }


### PR DESCRIPTION
Example:
```cpp
namespace Foo
{
	enum class Bar
	{
		A ,
		B,
		C,

		Max = C
	};

	constexpr bool EnableEnumAsNzFlags(Bar) { return true; }

	using BarFlags = Nz::Flags<Bar>;
}
```